### PR TITLE
ci: pin GitHub Actions with pinact

### DIFF
--- a/.github/workflows/summary.yaml
+++ b/.github/workflows/summary.yaml
@@ -10,8 +10,8 @@ jobs:
     name: generate-github-profile-summary-cards
 
     steps:
-      - uses: actions/checkout@v6.0.1
-      - uses: vn7n24fzkq/github-profile-summary-cards@v0.7.0
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: vn7n24fzkq/github-profile-summary-cards@5055b27ac896c627043ead432f9b2fa973aa2c80 # v0.7.0
         env: # you should replace with your personal access token
           GITHUB_TOKEN: ${{ secrets.github_token }}
         with:


### PR DESCRIPTION
Pinned GitHub Actions versions to commit hashes using pinact for better security and reproducibility.